### PR TITLE
Bump for nginx stable update

### DIFF
--- a/packer/root_image.pkr.hcl
+++ b/packer/root_image.pkr.hcl
@@ -71,7 +71,7 @@ variable "source_ami_name_prefix" {
 variable "vagrant_cloud_version" {
   type        = string
   description = "The version of the published vagrant box. Anything after a '-' will be removed in production."
-  default     = "11.11.5-${env("CIRCLE_WORKFLOW_ID")}"
+  default     = "11.11.6-${env("CIRCLE_WORKFLOW_ID")}"
 }
 
 variable "use_generated_security_group" {


### PR DESCRIPTION
Bumps `vagrant_cloud_version` 11.11.5 → 11.11.6 to cut a fresh root image.

Rebuilding root cascades through the downstream base/service images, which re-run apt and pick up current nginx stable. Same mechanism as our prior security/kernel bumps — no nginx pin lives here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)