### PR TITLE
Drop stale terraform provisioning docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,20 @@
 # Root Image Factory
 
-This provisions a CI/CD account in a multiaccount AWS setup and then uses that account to create root Debian 11 images.
+This uses Packer to create root Debian 11 images.
 
 #### A note on terminology
 
 We use `Root Image` to mean a completely unprovisioned bare image with nothing beyond a basic OS install. We use `Base Image` to mean a partially provisioned image with services required by all operational servers, e.g. monitoring, log aggregation, telemetry, etc.
 
 ## Local System Requirements
-- terraform >= 1.0
 - packer >= 1.7.3
 - ansible >= 4.3
 
-## Provisioning
-We use terraform workspaces, and the terraform module is configured such that use of the default workspace is invalid. The development workspace will configure and use our development Infrastructure AWS account, and the production workspace will correspondingly use our production Infrastructure AWS account.
+## Building
 
-Select a workspace with `terraform workspace select development`
-
-Then run `terraform plan -var-file=<workspace>.tfvars -out=run.tfplan`. Verify the proposed modifications. If they all look good, run `terraform apply run.tfplan` to apply changes.
-
-After running terraform, change to the root_image directory and run
+Change to the `packer` directory and run
 
 `packer build -timestamp-ui root_image.pkr.hcl`
 
-to build root Debian 11 AMIs and Vagrant boxes.
+to build root Debian 11 AMIs and Vagrant boxes. See `.circleci/config.yml` for how CI
+invokes this per account.


### PR DESCRIPTION
## Summary
README still documented the terraform workspace/plan/apply workflow that was removed in `1bcf6e0` ("Axe terraform.", 2025-07-23, -628 lines of .tf). Repo is Packer-only now (confirmed: no `terraform/` dir, `.circleci/config.yml` runs `buildomat/packer-build` only). Updated requirements and build steps to match reality.

Follow-up from C-1390's review (services#8 caught the same stale terraform label in services/CLAUDE.md; this is the repo-local copy of that mistake).

C-1390